### PR TITLE
Using Jekyll for index page generation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,16 @@
+# Site settings
+title: BlueBrain Software Directory
+organization: BlueBrain
+
+# Build settings
+markdown: kramdown
+
+# Do not exclude doxygen files starting with an underscore
+include: [ _*.html ]
+
+# Link to other documentation pages
+seealso: eyescale.github.io
+
+# The collection of documentation metadata
+collections:
+  - projects

--- a/_projects/Deflect-0.4.md
+++ b/_projects/Deflect-0.4.md
@@ -1,0 +1,6 @@
+---
+name: Deflect
+version: 0.4
+description: "The library to write applications for DisplayCluster"
+---
+

--- a/_projects/DisplayCluster-0.2.md
+++ b/_projects/DisplayCluster-0.2.md
@@ -1,0 +1,6 @@
+---
+name: DisplayCluster
+version: 0.2
+description: "The DisplayCluster project for driving large display walls"
+---
+

--- a/_projects/DisplayCluster-0.3.md
+++ b/_projects/DisplayCluster-0.3.md
@@ -1,0 +1,6 @@
+---
+name: DisplayCluster
+version: 0.3
+description: "The DisplayCluster project for driving large display walls"
+---
+

--- a/_projects/DisplayCluster-0.4.md
+++ b/_projects/DisplayCluster-0.4.md
@@ -1,0 +1,6 @@
+---
+name: DisplayCluster
+version: 0.4
+description: "The DisplayCluster project for driving large display walls"
+---
+

--- a/_projects/DisplayCluster-0.5.md
+++ b/_projects/DisplayCluster-0.5.md
@@ -1,0 +1,5 @@
+---
+name: DisplayCluster
+version: 0.5
+description: "The DisplayCluster project for driving large display walls"
+---

--- a/_projects/Hello-1.0.md
+++ b/_projects/Hello-1.0.md
@@ -1,0 +1,6 @@
+---
+name: Hello
+version: 1.0
+description: "Example project for the Blue Brain Project"
+---
+

--- a/_projects/codash-0.1.md
+++ b/_projects/codash-0.1.md
@@ -1,0 +1,6 @@
+---
+name: codash
+version: 0.1
+description: "Serialization & distribution support for DASH via Collage"
+---
+

--- a/_projects/dash-1.0.md
+++ b/_projects/dash-1.0.md
@@ -1,0 +1,7 @@
+---
+name: dash
+version: 1.0
+description: "C++ library for generic, efficient and thread-safe Data Access and Sharing"
+packageurl: https://launchpad.net/~eilemann/+archive/ubuntu/equalizer
+---
+

--- a/index.html
+++ b/index.html
@@ -1,42 +1,74 @@
+---
+---
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//ENhttp://www.w3.org/TR/html4/loose.dtd">
 <html>
   <head>
-    <title>BlueBrain Software Directory</title>
-    <link rel="stylesheet" href="css/github.css" type="text/css">  </head>
-  <body>
-  <div class="toc">    <h2 style="text-align: center;">Projects</h2><a href="#Deflect">Deflect 0.4</a>
-    <div class="badges"><a href="git@github.com:tribal-tec/Deflect.git"><img src="images/git.png" alt="Source Repository"></a><a href="https://github.com/BlueBrain/Deflect/releases"><img src="images/package.png" alt="Packages"></a><a href="Deflect-0.4/index.html"><img src="images/help.png"></a>
-      <img src="images/EP.png" alt="Exploratory">
-    </div><div class="flush"></div><a href="#DisplayCluster">DisplayCluster 0.5</a>
-    <div class="badges"><a href="https://github.com/BlueBrain/DisplayCluster.git"><img src="images/git.png" alt="Source Repository"></a><a href="https://github.com/BlueBrain/DisplayCluster/releases"><img src="images/package.png" alt="Packages"></a><a href="DisplayCluster-0.5/index.html"><img src="images/help.png"></a>
-      <img src="images/EP.png" alt="Exploratory">
-    </div><div class="flush"></div><a href="#Hello">Hello 1.0</a>
-    <div class="badges"><a href="https://github.com/BlueBrain/Hello.git"><img src="images/git.png" alt="Source Repository"></a><a href="https://launchpad.net/~eilemann/+archive/equalizer-dev"><img src="images/package.png" alt="Packages"></a><a href="Hello-1.0/index.html"><img src="images/help.png"></a>
-      <img src="images/EP.png" alt="Exploratory">
-    </div><div class="flush"></div><a href="#codash">codash 0.1</a>
-    <div class="badges"><a href="https://github.com/BlueBrain/codash.git"><img src="images/git.png" alt="Source Repository"></a><a href="https://launchpad.net/~eilemann/+archive/equalizer-dev"><img src="images/package.png" alt="Packages"></a><a href="codash-0.1/index.html"><img src="images/help.png"></a>
-      <img src="images/EP.png" alt="Exploratory">
-    </div><div class="flush"></div><a href="#dash">dash 1.0</a>
-    <div class="badges"><a href="https://github.com/BlueBrain/dash.git"><img src="images/git.png" alt="Source Repository"></a><a href="dash-1.0/index.html"><img src="images/help.png"></a>
-      <img src="images/EP.png" alt="Exploratory">
-    </div><div class="flush"></div><p>See also <a href='https://eyescale.github.io'>eyescale.github.io</a></p>
-  </div>
-  <div class="content">
-    <h1>BlueBrain Software Directory</h1>
-     <a name="Deflect"></a><h2>Deflect 0.4</h2>
-    <p>The library to write applications for DisplayCluster</p>
-    <div class="factoid"><a href="Deflect-0.4/index.html"><img src="images/help.png"> API Documentation</a></div><div class="factoid"><a href="git@github.com:tribal-tec/Deflect.git"><img src="images/git.png" alt="Git source repository"> Source Repository</a></div><div class="factoid"><a href="https://github.com/BlueBrain/Deflect/issues"><img src="images/issues.png" alt="Project Issues"> Project Issues</a></div><div class="factoid"><a href="https://github.com/BlueBrain/Deflect/releases"><img src="images/package.png" alt="Packages"> Packages</a></div><div class="factoid"><a href="git@travis-ci.org:tribal-tec/Deflect"><img src="git@travis-ci.org:tribal-tec/Deflect.png" alt="Continuous Integration"> Continuous Integration</a></div>
-    <div class="factoid"><img src="images/EP.png" alt="Exploratory"> Exploratory Code Quality</div><div class="factoid"><img src="images/help.png"> Old Versions:</div><div class="flush"> <a name="DisplayCluster"></a><h2>DisplayCluster 0.5</h2>
-    <p>The DisplayCluster project</p>
-    <div class="factoid"><a href="DisplayCluster-0.5/index.html"><img src="images/help.png"> API Documentation</a></div><div class="factoid"><a href="https://github.com/BlueBrain/DisplayCluster.git"><img src="images/git.png" alt="Git source repository"> Source Repository</a></div><div class="factoid"><a href="https://bbpteam.epfl.ch/project/issues/browse/DISCL"><img src="images/issues.png" alt="Project Issues"> Project Issues</a></div><div class="factoid"><a href="https://github.com/BlueBrain/DisplayCluster/releases"><img src="images/package.png" alt="Packages"> Packages</a></div><div class="factoid"><a href="https://travis-ci.org/BlueBrain/DisplayCluster"><img src="https://travis-ci.org/BlueBrain/DisplayCluster.png" alt="Continuous Integration"> Continuous Integration</a></div><div class="factoid"><a href="DisplayCluster-0.5/CoverageReport/index.html"><img src="images/search.png" alt="Test Coverage Report"> Test Coverage Report</a></div>
-    <div class="factoid"><img src="images/EP.png" alt="Exploratory"> Exploratory Code Quality</div><div class="factoid"><img src="images/help.png"> Old Versions: <a href="DisplayCluster-0.4/index.html">0.4</a> <a href="DisplayCluster-0.3/index.html">0.3</a> <a href="DisplayCluster-0.2/index.html">0.2</a></div><div class="flush"> <a name="Hello"></a><h2>Hello 1.0</h2>
-    <p>Example project for the Blue Brain Project</p>
-    <div class="factoid"><a href="Hello-1.0/index.html"><img src="images/help.png"> API Documentation</a></div><div class="factoid"><a href="https://github.com/BlueBrain/Hello.git"><img src="images/git.png" alt="Git source repository"> Source Repository</a></div><div class="factoid"><a href="https://github.com/BlueBrain/Hello/issues"><img src="images/issues.png" alt="Project Issues"> Project Issues</a></div><div class="factoid"><a href="https://launchpad.net/~eilemann/+archive/equalizer-dev"><img src="images/package.png" alt="Packages"> Packages</a></div><div class="factoid"><a href="https://travis-ci.org/BlueBrain/Hello"><img src="https://travis-ci.org/BlueBrain/Hello.png" alt="Continuous Integration"> Continuous Integration</a></div><div class="factoid"><a href="Hello-1.0/CoverageReport/index.html"><img src="images/search.png" alt="Test Coverage Report"> Test Coverage Report</a></div>
-    <div class="factoid"><img src="images/EP.png" alt="Exploratory"> Exploratory Code Quality</div><div class="factoid"><img src="images/help.png"> Old Versions:</div><div class="flush"> <a name="codash"></a><h2>codash 0.1</h2>
-    <p>Serialization & distribution support for DASH via Collage</p>
-    <div class="factoid"><a href="codash-0.1/index.html"><img src="images/help.png"> API Documentation</a></div><div class="factoid"><a href="https://github.com/BlueBrain/codash.git"><img src="images/git.png" alt="Git source repository"> Source Repository</a></div><div class="factoid"><a href="https://github.com/BlueBrain/codash/issues"><img src="images/issues.png" alt="Project Issues"> Project Issues</a></div><div class="factoid"><a href="https://launchpad.net/~eilemann/+archive/equalizer-dev"><img src="images/package.png" alt="Packages"> Packages</a></div><div class="factoid"><a href="https://travis-ci.org/BlueBrain/codash"><img src="https://travis-ci.org/BlueBrain/codash.png" alt="Continuous Integration"> Continuous Integration</a></div><div class="factoid"><a href="codash-0.1/CoverageReport/index.html"><img src="images/search.png" alt="Test Coverage Report"> Test Coverage Report</a></div>
-    <div class="factoid"><img src="images/EP.png" alt="Exploratory"> Exploratory Code Quality</div><div class="factoid"><img src="images/help.png"> Old Versions:</div><div class="flush"> <a name="dash"></a><h2>dash 1.0</h2>
-    <p></p>
-    <div class="factoid"><a href="dash-1.0/index.html"><img src="images/help.png"> API Documentation</a></div><div class="factoid"><a href="https://github.com/BlueBrain/dash.git"><img src="images/git.png" alt="Git source repository"> Source Repository</a></div><div class="factoid"><a href="https://github.com/BlueBrain/dash/issues"><img src="images/issues.png" alt="Project Issues"> Project Issues</a></div><div class="factoid"><a href="https://travis-ci.org/BlueBrain/dash"><img src="https://travis-ci.org/BlueBrain/dash.png" alt="Continuous Integration"> Continuous Integration</a></div><div class="factoid"><a href="dash-1.0/CoverageReport/index.html"><img src="images/search.png" alt="Test Coverage Report"> Test Coverage Report</a></div>
-    <div class="factoid"><img src="images/EP.png" alt="Exploratory"> Exploratory Code Quality</div><div class="factoid"><img src="images/help.png"> Old Versions:</div>
+    <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
+    <link rel="stylesheet" href="css/github.css" type="text/css">
+  </head>
+    <body>
+    {% assign projectsByName = site.projects | group_by:"name" %}
+    <div class="toc">
+      <h2 style="text-align: center;">Projects</h2>
+      {% for project in projectsByName %}
+      {% assign entry = project.items.last %}
+      <div class="project-menu-entry">
+        <a href="#{{ project.name }}">{{ project.name }} {{ entry.version }}</a>
+        <div class="badges">
+          <a href="https://github.com/{{ site.organization }}/{{ project.name }}.git"><img src="images/git.png" alt="Source Repository"></a>
+          <a href="{{ project.name }}-{{ entry.version }}/index.html"><img src="images/help.png"></a>
+        </div>
+        <div class="flush"></div>
+      </div>
+      {% endfor %}
+      {% if site.seealso %}
+      <p>See also <a href='https://{{ site.seealso }}'>{{ site.seealso }}</a></p>
+      {% endif %}
+    </div>
+    <div class="content">
+    <h1>{{ site.organization }} Software Directory</h1>
+      {% for project in projectsByName %}
+      {% assign entry = project.items.last %}
+      <div class="project">
+        {% if entry.issuesurl %}
+        {% assign issuesurl = entry.issuesurl %}
+        {% else %}
+        {% capture issuesurl %}https://github.com/{{ site.organization }}/{{ project.name }}/issues{% endcapture %}
+        {% endif %}
+        {% if entry.packageurl %}
+        {% assign packageurl = entry.packageurl %}
+        {% else %}
+        {% capture packageurl %}https://github.com/{{ site.organization }}/{{ project.name }}/releases{% endcapture %}
+        {% endif %}
+        <h2>{{ project.name }} {{ entry.version }}</h2>
+        <p>{{ entry.description }}</p>
+        <div class="factoid"><a href="{{ project.name }}-{{ entry.version }}/index.html"><img src="images/help.png"> API Documentation</a></div>
+        <div class="factoid"><a href="{{ project.name }}-{{ entry.version }}/CoverageReport/index.html"><img src="images/search.png" alt="Test Coverage Report"> Test Coverage Report</a></div>
+        <div class="factoid"><a href="https://github.com/{{ site.organization }}/{{ project.name }}.git"><img src="images/git.png" alt="Git source repository"> Source Repository</a></div>
+        <div class="factoid"><a href="{{ issuesurl }}"><img src="images/issues.png" alt="Project Issues"> Project Issues</a></div>
+        <div class="factoid"><a href="{{ packageurl }}"><img src="images/package.png" alt="Packages"> Packages</a></div>
+        <!-- <div class="factoid"><a href="https://travis-ci.org/{{ site.organization }}/{{ project.name }}"><img src="https://travis-ci.org/{{ site.organization }}/{{ project.name }}.png" alt="Continuous Integration"> Continuous Integration</a></div> -->
+        {% case entry.maturity %}
+        {% when 'RS' %}
+        <div class="factoid"><img src="images/RS.png" alt="Research Stable" /> Research Stable Code Quality</div>
+        {% when 'RD' %}
+        <div class="factoid"><img src="images/RD.png" alt="Research Development" /> Research Development Code Quality</div>
+        {% else %}
+        <div class="factoid"><img src="images/EP.png" alt="Exploratory" /> Exploratory Code Quality</div>
+        {% endcase %}
+        {% if project.items.size > 1 %}
+        <div class="factoid"><img src="images/help.png"> Old Versions:
+          {% for oldentry in project.items reversed limit:3 %}
+          {% if oldentry != entry %}
+          <a href="{{ project.name }}-{{ oldentry.version }}/index.html">{{ oldentry.version }}</a>
+          {% endif %}
+          {% endfor %}
+        </div>
+        {% endif %}
+        <div class="flush"></div>
+      </div>
+      {% endfor %}
+    </div>
+  </body>
 </html>
+


### PR DESCRIPTION
@eile Please review the new concept.
Once we have validated that Jekyll works as expected on github pages, I will update the CMake logic to deploy the metadata files to the _projects folder via the doxycopy target. Later, we can remove all CMake logic from this repo and eyescale.